### PR TITLE
🔧 Configure authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Create your local `appsettings.Development.json` with:
       },
       "cdn": {
         "url": "https://das-prd-frnt-end.azureedge.net"
+      },
+      "Authentication": {
+        "MetadataAddress": "https://localhost:5001/"
+      },
+      "Api": {
+        "BaseUrl":  "https://localhost:8088"
       }
     }
 

--- a/src/SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests/Bindings/Web.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests/Bindings/Web.cs
@@ -29,6 +29,7 @@ namespace SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests.Bindings
                 var config = new Dictionary<string, string>
                 {
                     {"EnvironmentName", "ACCEPTANCE_TESTS"},
+                    {"Api:BaseUrl", _context.OuterApi.BaseAddress},
                 };
 
                 ActionResultHook = new Hook<IActionResult>();

--- a/src/SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests/LocalWebApplicationFactory.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests/LocalWebApplicationFactory.cs
@@ -28,12 +28,7 @@ namespace SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests
         protected override IHostBuilder CreateHostBuilder()
         {
             var builder = Host.CreateDefaultBuilder()
-                .ConfigureWebHostDefaults(x =>
-                {
-                    x.ConfigureServices(s =>
-                        s.Configure<OuterApiConfig>(a => a.BaseUrl = _testContext.OuterApi.BaseAddress.ToString()));
-                    x.UseStartup<TEntryPoint>();
-                });
+                .ConfigureWebHostDefaults(x => x.UseStartup<TEntryPoint>());
             return builder;
         }
 
@@ -56,7 +51,6 @@ namespace SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests
 
             builder.ConfigureAppConfiguration(a =>
             {
-                a.Sources.Clear();
                 a.AddInMemoryCollection(_config);
             });
             builder.UseEnvironment("LOCAL");

--- a/src/SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests/Steps/ConfirmIdentitySteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web.AcceptanceTests/Steps/ConfirmIdentitySteps.cs
@@ -1,9 +1,7 @@
 ﻿using FluentAssertions;
-using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeCommitments.Web.Pages;
 using System;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using TechTalk.SpecFlow;

--- a/src/SFA.DAS.ApprenticeCommitments.Web/SFA.DAS.ApprenticeCommitments.Web.csproj
+++ b/src/SFA.DAS.ApprenticeCommitments.Web/SFA.DAS.ApprenticeCommitments.Web.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.11" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.1.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.11" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />

--- a/src/SFA.DAS.ApprenticeCommitments.Web/Startup/ApplicationConfiguration.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web/Startup/ApplicationConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.ApprenticeCommitments.Web.Startup
+{
+    public class ApplicationConfiguration
+    {
+        public AuthenticationServiceConfiguration Authentication { get; set; }
+        public DataProtectionConnectionStrings ConnectionStrings { get; set; }
+        public OuterApiConfiguration Api { get; set; }
+    }
+}

--- a/src/SFA.DAS.ApprenticeCommitments.Web/Startup/ApplicationStartup.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web/Startup/ApplicationStartup.cs
@@ -2,8 +2,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace SFA.DAS.ApprenticeCommitments.Web.Startup
 {
@@ -21,13 +19,14 @@ namespace SFA.DAS.ApprenticeCommitments.Web.Startup
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<OuterApiConfig>(Configuration.GetSection("OuterApiConfig"));
-            services.AddSingleton(s => s.GetRequiredService<IOptions<OuterApiConfig>>().Value);
+            var appConfig = Configuration.Get<ApplicationConfiguration>();
 
             services
                 .AddApplicationInsightsTelemetry()
-                .AddDataProtection(Configuration, Environment)
-                .RegisterServices(Configuration)
+                .AddDataProtection(appConfig.ConnectionStrings, Environment)
+                .AddAuthentication(appConfig.Authentication)
+                .AddOuterApi(appConfig.Api)
+                .RegisterServices()
                 .AddRazorPages();
         }
 

--- a/src/SFA.DAS.ApprenticeCommitments.Web/Startup/AuthenticationStartup.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web/Startup/AuthenticationStartup.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Logging;
+using System.IdentityModel.Tokens.Jwt;
+
+namespace SFA.DAS.ApprenticeCommitments.Web.Startup
+{
+    public static class AuthenticationStartup
+    {
+        public static IServiceCollection AddAuthentication(
+            this IServiceCollection services,
+            AuthenticationServiceConfiguration config)
+        {
+            JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+
+            IdentityModelEventSource.ShowPII = true;
+
+            services
+                .AddAuthentication(options =>
+                {
+                    options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                    options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+                })
+                .AddCookie("Cookies")
+                .AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, options =>
+                {
+                    options.SignInScheme = "Cookies";
+                    options.Authority = config.MetadataAddress;
+                    options.RequireHttpsMetadata = false;
+                    options.ClientId = "apprentice";
+
+                    options.Scope.Clear();
+                    options.Scope.Add("openid");
+                    options.Scope.Add("profile");
+
+                    options.SaveTokens = true;
+
+                    options.DisableTelemetry = false;
+                });
+
+            services.AddAuthorization();
+
+            return services;
+        }
+    }
+
+    public class AuthenticationServiceConfiguration
+    {
+        public string MetadataAddress { get; set; }
+    }
+}

--- a/src/SFA.DAS.ApprenticeCommitments.Web/Startup/DataProtectionStartup.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web/Startup/DataProtectionStartup.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using StackExchange.Redis;
@@ -11,19 +10,15 @@ namespace SFA.DAS.ApprenticeCommitments.Web.Startup
     {
         public static IServiceCollection AddDataProtection(
             this IServiceCollection services,
-            IConfiguration configuration,
+            DataProtectionConnectionStrings configuration,
             IWebHostEnvironment environment)
         {
             if (!environment.IsDevelopment())
             {
-                var redisConfiguration = configuration
-                    .GetSection("ConnectionStrings")
-                    .Get<DataProtectionConnectionStrings>();
-
-                if (redisConfiguration != null)
+                if (configuration != null)
                 {
-                    var redisConnectionString = redisConfiguration.RedisConnectionString;
-                    var dataProtectionKeysDatabase = redisConfiguration.DataProtectionKeysDatabase;
+                    var redisConnectionString = configuration.RedisConnectionString;
+                    var dataProtectionKeysDatabase = configuration.DataProtectionKeysDatabase;
 
                     var redis = ConnectionMultiplexer
                         .Connect($"{redisConnectionString},{dataProtectionKeysDatabase}");
@@ -37,7 +32,7 @@ namespace SFA.DAS.ApprenticeCommitments.Web.Startup
         }
     }
 
-    internal class DataProtectionConnectionStrings
+    public class DataProtectionConnectionStrings
     {
         public string RedisConnectionString { get; set; }
         public string DataProtectionKeysDatabase { get; set; }

--- a/src/SFA.DAS.ApprenticeCommitments.Web/Startup/ServicesStartup.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web/Startup/ServicesStartup.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using RestEase.HttpClientFactory;
 using SFA.DAS.ApprenticeCommitments.Web.Api;
@@ -8,20 +7,22 @@ namespace SFA.DAS.ApprenticeCommitments.Web.Startup
     public static class ServicesStartup
     {
         public static IServiceCollection RegisterServices(
-            this IServiceCollection services,
-            IConfiguration configuration)
+            this IServiceCollection services)
         {
             services.AddTransient<RegistrationsService>();
+            return services;
+        }
 
-            var outerApiConfig = services.BuildServiceProvider().GetRequiredService<OuterApiConfig>();
-            var url = outerApiConfig.BaseUrl;
-            services.AddRestEaseClient<IApiClient>(url);
-
+        public static IServiceCollection AddOuterApi(
+            this IServiceCollection services,
+            OuterApiConfiguration configuration)
+        {
+            services.AddRestEaseClient<IApiClient>(configuration.BaseUrl);
             return services;
         }
     }
 
-    public class OuterApiConfig
+    public class OuterApiConfiguration
     {
         public string BaseUrl { get; set; }
     }

--- a/src/SFA.DAS.ApprenticeCommitments.Web/appsettings.json
+++ b/src/SFA.DAS.ApprenticeCommitments.Web/appsettings.json
@@ -9,5 +9,8 @@
   "AllowedHosts": "*",
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true",
   "ConfigNames": "SFA.DAS.ApprenticeCommitments.Web",
-  "EnvironmentName": "LOCAL"
+  "EnvironmentName": "LOCAL",
+  "Authentication": {
+    "MetadataAddress": "https://localhost:5001/"
+  }
 }


### PR DESCRIPTION
Requires a change to `das-employer-config` - see SkillsFundingAgency/das-employer-config#787.

For development this `appsettings.Development.json` can be used:

    {
      "Logging": {
        "LogLevel": {
          "Default": "Information",
          "Microsoft": "Warning",
          "Microsoft.Hosting.Lifetime": "Information"
        }
      },
      "ConnectionStrings": {
        "RedisConnectionString": "localhost",
        "DataProtectionKeysDatabase": "DefaultDatabase=3"
      },
      "cdn": {
        "url": "https://das-prd-frnt-end.azureedge.net"
      },
      "Authentication": {
        "MetadataAddress": "https://localhost:5001/"
      },
      "Api": {
        "BaseUrl":  "https://localhost:8088"
      }
    }
