### PR TITLE
Removed "pr: none" parameter from azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,8 +4,6 @@ trigger:
     include:
       - "*"
 
-pr: none
-
 variables:
 - name: SolutionBaseName
   value: 'SFA.DAS.ApprenticeCommitments.Web'


### PR DESCRIPTION
Removed "pr: none" parameter from azure-pipelines.yml to see if it will allow PR builds as requested by Dan Beavon and Roy Bailey with regards to SonarCloud branch monitoring functionality