### PR TITLE
Make WireMock default be the happy path

### DIFF
--- a/src/SFA.DAS.ApprenticeCommitments.Web.MockServer/ApprenticeCommitmentsApiBuilder.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web.MockServer/ApprenticeCommitmentsApiBuilder.cs
@@ -3,10 +3,12 @@ using Newtonsoft.Json.Serialization;
 using SFA.DAS.ApprenticeCommitments.Web.Services.OuterApi;
 using System;
 using System.Net;
+using WireMock.Logging;
 using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
+using WireMock.Settings;
 
 namespace SFA.DAS.ApprenticeCommitments.Web.MockServer
 {
@@ -18,7 +20,13 @@ namespace SFA.DAS.ApprenticeCommitments.Web.MockServer
 
         public ApprenticeCommitmentsApiBuilder(int port)
         {
-            _server = WireMockServer.StartWithAdminInterface(port, true);
+            _server = WireMockServer.Start(new WireMockServerSettings
+            {
+                Port = port,
+                UseSSL = true,
+                StartAdminInterface = true,
+                Logger = new WireMockConsoleLogger(),
+            });
         }
 
         public static ApprenticeCommitmentsApiBuilder Create(int port)

--- a/src/SFA.DAS.ApprenticeCommitments.Web.MockServer/Program.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Web.MockServer/Program.cs
@@ -9,13 +9,13 @@ namespace SFA.DAS.ApprenticeCommitments.Web.MockServer
             ApprenticeCommitmentsApiBuilder.Create(5121)
                 .WithRegistrationFirstSeenOn()
                 .WithUsersFirstLogin()
+                .WithUserAccount()
                 .WithUsersApprenticeships()
                 .WithEmployerConfirmation()
                 .WithTrainingProviderConfirmation()
                 .WithApprenticeshipDetailsConfirmation()
                 .WithHowApprenticeshipWillBeDeliveredConfirmation()
                 .WithRolesAndResponsibilitiesConfirmation()
-                .WithUserAccount()
                 .Build();
 
             Console.WriteLine("Press any key to stop the servers");


### PR DESCRIPTION
Confirming an apprenticeship is the happy path so this is now the default state of WireMock.